### PR TITLE
Fix overlay position to top of browser window

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,71 @@
             faucibus vestibulum arcu non dictum. Nullam quis volutpat arcu, sit
             amet viverra ante.
           </p>
+          <p>
+            Curabitur ut lacus vitae massa congue sagittis vitae blandit magna.
+            Fusce pharetra arcu risus, a tempor tortor convallis vitae. Sed varius
+            fermentum metus, id placerat eros hendrerit ullamcorper. Suspendisse
+            porta felis odio, eu sollicitudin dui tristique ut. Ut ullamcorper leo
+            nec sodales tempus. Nunc porttitor et libero in dignissim. Proin
+            euismod eleifend erat. Vivamus nec aliquam ex. Ut aliquet venenatis
+            diam, vitae sollicitudin ligula suscipit vel. Suspendisse et justo
+            sapien. Etiam eleifend mauris non orci fringilla vulputate. Ut
+            imperdiet magna faucibus, sagittis ex eu, sagittis tellus. Vestibulum
+            faucibus vestibulum arcu non dictum. Nullam quis volutpat arcu, sit
+            amet viverra ante.
+          </p>
+          <p>
+            Curabitur ut lacus vitae massa congue sagittis vitae blandit magna.
+            Fusce pharetra arcu risus, a tempor tortor convallis vitae. Sed varius
+            fermentum metus, id placerat eros hendrerit ullamcorper. Suspendisse
+            porta felis odio, eu sollicitudin dui tristique ut. Ut ullamcorper leo
+            nec sodales tempus. Nunc porttitor et libero in dignissim. Proin
+            euismod eleifend erat. Vivamus nec aliquam ex. Ut aliquet venenatis
+            diam, vitae sollicitudin ligula suscipit vel. Suspendisse et justo
+            sapien. Etiam eleifend mauris non orci fringilla vulputate. Ut
+            imperdiet magna faucibus, sagittis ex eu, sagittis tellus. Vestibulum
+            faucibus vestibulum arcu non dictum. Nullam quis volutpat arcu, sit
+            amet viverra ante.
+          </p>
+          <p>
+            Curabitur ut lacus vitae massa congue sagittis vitae blandit magna.
+            Fusce pharetra arcu risus, a tempor tortor convallis vitae. Sed varius
+            fermentum metus, id placerat eros hendrerit ullamcorper. Suspendisse
+            porta felis odio, eu sollicitudin dui tristique ut. Ut ullamcorper leo
+            nec sodales tempus. Nunc porttitor et libero in dignissim. Proin
+            euismod eleifend erat. Vivamus nec aliquam ex. Ut aliquet venenatis
+            diam, vitae sollicitudin ligula suscipit vel. Suspendisse et justo
+            sapien. Etiam eleifend mauris non orci fringilla vulputate. Ut
+            imperdiet magna faucibus, sagittis ex eu, sagittis tellus. Vestibulum
+            faucibus vestibulum arcu non dictum. Nullam quis volutpat arcu, sit
+            amet viverra ante.
+          </p>
+          <p>
+            Curabitur ut lacus vitae massa congue sagittis vitae blandit magna.
+            Fusce pharetra arcu risus, a tempor tortor convallis vitae. Sed varius
+            fermentum metus, id placerat eros hendrerit ullamcorper. Suspendisse
+            porta felis odio, eu sollicitudin dui tristique ut. Ut ullamcorper leo
+            nec sodales tempus. Nunc porttitor et libero in dignissim. Proin
+            euismod eleifend erat. Vivamus nec aliquam ex. Ut aliquet venenatis
+            diam, vitae sollicitudin ligula suscipit vel. Suspendisse et justo
+            sapien. Etiam eleifend mauris non orci fringilla vulputate. Ut
+            imperdiet magna faucibus, sagittis ex eu, sagittis tellus. Vestibulum
+            faucibus vestibulum arcu non dictum. Nullam quis volutpat arcu, sit
+            amet viverra ante.
+          </p>
+          <p>
+            Curabitur ut lacus vitae massa congue sagittis vitae blandit magna.
+            Fusce pharetra arcu risus, a tempor tortor convallis vitae. Sed varius
+            fermentum metus, id placerat eros hendrerit ullamcorper. Suspendisse
+            porta felis odio, eu sollicitudin dui tristique ut. Ut ullamcorper leo
+            nec sodales tempus. Nunc porttitor et libero in dignissim. Proin
+            euismod eleifend erat. Vivamus nec aliquam ex. Ut aliquet venenatis
+            diam, vitae sollicitudin ligula suscipit vel. Suspendisse et justo
+            sapien. Etiam eleifend mauris non orci fringilla vulputate. Ut
+            imperdiet magna faucibus, sagittis ex eu, sagittis tellus. Vestibulum
+            faucibus vestibulum arcu non dictum. Nullam quis volutpat arcu, sit
+            amet viverra ante.
+          </p>
         </div>
       </div>
     </main>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/sass/global-nav.scss
+++ b/src/sass/global-nav.scss
@@ -264,6 +264,7 @@ $global-nav-link-color: #3097ff;
     opacity: 0;
     pointer-events: none;
     position: fixed;
+    top: 0;
     width: 100%;
     z-index: 97;
 


### PR DESCRIPTION
## Done

- A holdover from the previous version of the global nav included space at the top of the overlay to accommodate a navigation below the globa nav element - this is no longer required, so it has been removed.
- increased amount of content on the demo page to demonstrate the fix
- bumped version to 3.1.1

## QA
- Visit https://global-nav-226.demos.haus/
- Open the "All Canonical" dropdown
- Scroll down
- See that there is no space above the overlay when the dropdown isn't visible anymore, unlike this:
![Peek 2022-09-06 11-15](https://user-images.githubusercontent.com/2376968/188610905-4d0b7e11-cc7d-43d4-a571-c5d80c0b444d.gif)
