### PR TITLE
add breakpoint argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,31 @@ createNav();
 
 3. You will then need to add the `.global-nav` class to a `ul.p-navigation__items` element within the navigation pattern. The module will look for this class and add the dropdown as the first item in the list.
 
+### Options
+
+The `createNav` function takes an object of options with the following property:
+
+- `breakpoint`: The point, in pixels, at which the navigation switches between desktop and mobile layouts. The default is `620px`, which is meant to reflect the default value of `$breakpoint-navigation-threshold` in Vanilla (see [Vanilla's breakpoint documentation](https://vanillaframework.io/docs/settings/breakpoint-settings)).
+
+If the `$breakpoint-navigation-threshold` Vanilla variable is overridden in your project, you will need to set this option on the global nav.
+
+For example, to set the `breakpoint` to `1036px`:
+
+```html
+<script src="/node_modules/@canonical/global-nav/dist/index.js"></script>
+
+<script>
+  canonicalGlobalNav.createNav({ breakpoint: '1036px' });
+</script>
+```
+
+If you're importing;
+
+```js
+import { createNav } from '@canonical/global-nav';
+createNav({ breakpoint: '1036px' });
+```
+
 ## Building the Global nav
 
 To build the JS into the `/dist` folder, run:

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ The `createNav` function takes an object of options with the following property:
 
 If the `$breakpoint-navigation-threshold` Vanilla variable is overridden in your project, you will need to set this option on the global nav.
 
-For example, to set the `breakpoint` to `1036px`:
+For example, to set the `breakpoint` to `1036`:
 
 ```html
 <script src="/node_modules/@canonical/global-nav/dist/index.js"></script>
 
 <script>
-  canonicalGlobalNav.createNav({ breakpoint: '1036px' });
+  canonicalGlobalNav.createNav({ breakpoint: 1036 });
 </script>
 ```
 
@@ -65,7 +65,7 @@ If you're importing;
 
 ```js
 import { createNav } from '@canonical/global-nav';
-createNav({ breakpoint: '1036px' });
+createNav({ breakpoint: 1036 });
 ```
 
 ## Building the Global nav

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -27,7 +27,7 @@ function createMobileDropdown(products) {
 
   const mobileAbouts = abouts.map(about => createListItem(about)).join('');
 
-  const mobileDropdown = `<li class="u-hide--medium u-hide--large">
+  const mobileDropdown = `<li id="all-canonical-mobile" class="u-hide">
     <ul class="p-navigation__items">
       <li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle">
         <a href="#products" class="p-navigation__link global-nav__header-link-anchor">Products</a>
@@ -196,7 +196,22 @@ function createProductDropdown(products) {
   return productDropdown;
 }
 
-function addListeners(wrapper) {
+function showAppropriateNavigation(breakpoint) {
+  /* eslint-disable */
+  const desktopNav = document.getElementById('all-canonical');
+  const mobileNav = document.getElementById('all-canonical-mobile');
+
+  if (window.innerWidth >= parseInt(breakpoint)) {
+    desktopNav.classList.remove('u-hide');
+    mobileNav.classList.add('u-hide');
+  } else {
+    desktopNav.classList.add('u-hide');
+    mobileNav.classList.remove('u-hide');
+  }
+  /* eslint-enable */
+}
+
+function addListeners(wrapper, breakpoint) {
   const primaryDropdownCTA = wrapper.querySelector('#all-canonical-link');
   const headerLinks = wrapper.querySelectorAll(
     '.global-nav__dropdown-toggle .global-nav__header-link-anchor'
@@ -282,9 +297,15 @@ function addListeners(wrapper) {
       primaryDropdownCTA.focus();
     }
   });
+
+  /* eslint-disable */
+  window.addEventListener('resize', () => {
+    showAppropriateNavigation(breakpoint);
+  });
+  /* eslint-enable */
 }
 
-export const createNav = () => {
+export const createNav = ({ breakpoint = '620px' } = {}) => {
   // Recruitment call to action
   // eslint-disable-next-line no-console
   console.log(
@@ -300,7 +321,7 @@ export const createNav = () => {
   const overlay = createFromHTML('<div class="global-nav-overlay"></div>');
 
   const navItem =
-    createFromHTML(`<li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle u-hide--mobile" id="all-canonical">
+    createFromHTML(`<li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle u-hide" id="all-canonical">
       <a href="#canonical-products" aria-controls="canonical-products" class="p-navigation__link global-nav__header-link-anchor" id="all-canonical-link" aria-expanded="false">All Canonical</a>
     </li>`);
 
@@ -323,7 +344,8 @@ export const createNav = () => {
   if (container) {
     container.prepend(navItem);
     container.prepend(mobileDropdown);
+    showAppropriateNavigation(breakpoint);
     // Add event listeners
-    addListeners(container);
+    addListeners(container, breakpoint);
   }
 };

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -1,5 +1,22 @@
 import { canonicalProducts } from './product-details';
 
+function debounce(func, wait, immediate) {
+  let timeout;
+
+  return () => {
+    const context = this;
+    const args = arguments; // eslint-disable-line
+    const later = () => {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    const callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+}
+
 function createFromHTML(html) {
   const div = window.document.createElement('div'); //eslint-disable-line
   div.innerHTML = html;

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -201,7 +201,7 @@ function showAppropriateNavigation(breakpoint) {
   const desktopNav = document.getElementById('all-canonical');
   const mobileNav = document.getElementById('all-canonical-mobile');
 
-  if (window.innerWidth >= parseInt(breakpoint)) {
+  if (window.innerWidth >= breakpoint) {
     desktopNav.classList.remove('u-hide');
     mobileNav.classList.add('u-hide');
   } else {
@@ -299,13 +299,16 @@ function addListeners(wrapper, breakpoint) {
   });
 
   /* eslint-disable */
-  window.addEventListener('resize', () => {
-    showAppropriateNavigation(breakpoint);
-  });
+  window.addEventListener(
+    'resize',
+    debounce(() => {
+      showAppropriateNavigation(breakpoint);
+    })
+  );
   /* eslint-enable */
 }
 
-export const createNav = ({ breakpoint = '620px' } = {}) => {
+export const createNav = ({ breakpoint = 620 } = {}) => {
   // Recruitment call to action
   // eslint-disable-next-line no-console
   console.log(


### PR DESCRIPTION
## Done

The new version of the global-nav sits within the new Vanilla navigation pattern, which responds to a `$breakpoint-navigation-threshold` that can be changed within a given project. The global nav module needs to be able to respond to the same breakpoint setting, as it includes different views for mobile and desktop. Previously it was responding to small, medium and large breakpoints, which won't do.

As far as I could tell, there's no way for a module to read a SCSS variable set in a parent project, so instead I have added the ability to define the breakpoint as an argument when calling the global-nav `createNav` function.

## QA

- Check out this branch
- In one terminal, `dotrun` the project
- In a second terminal `dotrun watch` the project
- Visit http://0.0.0.0:8300/
- Resize the browser and see that the navigation switches between the mobile and desktop views correctly
- In index.html, find the `createNav` call
- Pass a `breakpoint` argument to the function e.g.
```js
createNav({breakpoint: '1036px'});
```
- Refresh http://0.0.0.0:8300/
- Resize the browser and see that the mobile navigation items appear up to the new breakpoint, and disappear at or above that breakpoint, where they are replaced by the "All Canonical" item