### PR TITLE
Fix overlay bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -217,12 +217,15 @@ function showAppropriateNavigation(breakpoint) {
   /* eslint-disable */
   const desktopNav = document.getElementById('all-canonical');
   const mobileNav = document.getElementById('all-canonical-mobile');
+  const overlay = document.getElementById('all-canonical-overlay');
 
   if (window.innerWidth >= breakpoint) {
     desktopNav.classList.remove('u-hide');
+    overlay.classList.remove('u-hide');
     mobileNav.classList.add('u-hide');
   } else {
     desktopNav.classList.add('u-hide');
+    overlay.classList.add('u-hide');
     mobileNav.classList.remove('u-hide');
   }
   /* eslint-enable */
@@ -338,7 +341,9 @@ export const createNav = ({ breakpoint = 620 } = {}) => {
   const skipLink = createFromHTML(
     '<div class="skip-content" role="navigation"><a href="#main-content">Skip to main content</a></div'
   );
-  const overlay = createFromHTML('<div class="global-nav-overlay"></div>');
+  const overlay = createFromHTML(
+    '<div id="all-canonical-overlay" class="global-nav-overlay"></div>'
+  );
 
   const navItem =
     createFromHTML(`<li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle u-hide" id="all-canonical">


### PR DESCRIPTION
## Done

Fixed a bug where the overlay would remain visible when opening the "All Canonical" dropdown on desktop and resizing the browser to mobile width

## QA
- Visit https://global-nav-229.demos.haus/
- On desktop, open the "All Canonical" dropdown
- Resize the browser to mobile width
- See that the page content is not obscured by an opaque overlay