### PR TITLE
fire a custom event when the global nav is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -248,6 +248,7 @@ function addListeners(wrapper, breakpoint) {
     '.global-nav-dropdown__content'
   );
   const overlay = document.querySelector('.global-nav-overlay');
+  const event = new Event('global-nav-opened');
   /* eslint-enable */
 
   function closeNav(delay = 250) {
@@ -279,6 +280,8 @@ function addListeners(wrapper, breakpoint) {
     headerLink.classList.add('is-selected');
     headerLink.parentNode.classList.add('is-active');
     headerLink.setAttribute('aria-expanded', 'true');
+
+    document.dispatchEvent(event); //eslint-disable-line
 
     dropdownContents.forEach(menu => {
       if (menu !== targetMenu) {


### PR DESCRIPTION
## Done

- Added a custom event that is fired when the global nav is opened.
  - This allows the parent project to listen for the event and perform additional actions if it needs to e.g. ubuntu.com's meganav is much more complex than the standard Vanilla navigation pattern, but there's no way to attach standard event listeners to the appended global nav element. Listening for this event means we can close any other open meganav sections when the global nav is opened.

## QA

- Checkout this branch
- Run `dotrun build`
- In another project (one that includes global-nav, e.g. https://github.com/canonical/charmed-kubeflow.io), update the `global-nav` entry in package.json to point to your local copy of the global-nav repo, e.g.:
```
"@canonical/global-nav": "../global-nav",
```
- In the parent project (charmed-kubeflow, in this example), add the following script to the index.html template:
```
<script>
  document.addEventListener('global-nav-opened', () => {
    console.log('global nav opened')
  })
</script>
```
- `dotrun` the project and visit the index page
- open your browser console
- click "All Canonical" in the navigation
- you should see "global nav opened" appear in the console