### PR TITLE
Update to Vanilla 4.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Canonical global navigation demo</title>
     <meta name="description" content="Canonical global navigation demo" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-3.8.2.min.css" />
+    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.0.0.min.css" />
     <style type="text/css">
       body {
         display: block;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "3.2.5",
+  "version": "3.3.0",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "sass-lint": "1.13.1"
   },
   "dependencies": {
-    "vanilla-framework": "3.14.0"
+    "vanilla-framework": "4.0.0"
   }
 }

--- a/src/sass/global-nav.scss
+++ b/src/sass/global-nav.scss
@@ -98,7 +98,7 @@ $global-nav-link-color: #3097ff;
 
   .global-nav-dropdown__content {
     margin: 0 auto;
-    max-width: 72rem;
+    max-width: $grid-max-width;
     padding-top: 0;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4622,10 +4622,10 @@ util@^0.10.3:
   dependencies:
     inherits "2.0.3"
 
-vanilla-framework@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.14.0.tgz#c5b94d7e2e3ef2d3c9f24091b7efc4abf8054cf9"
-  integrity sha512-06Vr2nhjU72N9IivwCLcd7FgqFNopkiHfzANJUCNdvs8FkbTjIB7fcsFgJ6O76KnOBsEiAoJAssRkTh9x3a2jw==
+vanilla-framework@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.0.0.tgz#a2fee9bd9763ebd6932b764f9d66484dc177d4cc"
+  integrity sha512-fiPnmaTUe15l5MRNJ6IsiJ8qiunfmgtLETOFltaYiE/bQKL7xTI+riBak2iygBKeF1y0Gi/GxUNt4hyb6xDPKA==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- Updates global-nav to Vanilla 4.0
- Makes sure dropdown width is using Vanilla variable instead of hardcoded value


## QA

Check the demo, verify if global nav looks as expected: https://global-nav-263.demos.haus/
