### PR TITLE
Allow parsing of customer container class for mobile and desktop navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The `createNav` function takes an object of options with the following property:
 
 - `breakpoint`: The point, in pixels, at which the navigation switches between desktop and mobile layouts. The default is `620px`, which is meant to reflect the default value of `$breakpoint-navigation-threshold` in Vanilla (see [Vanilla's breakpoint documentation](https://vanillaframework.io/docs/settings/breakpoint-settings)).
 
+- `mobileContainerSelector` and `desktopContainerSelector`: Selectors (can be 'id' or 'class') of where to attach the mobile and desktop views of the global-nav. This will also circumvent the default eventListeners being attached as they are dependent on the default structure, so custom JS will be nessacary. Also in this case, the class `global-nav` should still be used to indicate the position of the 'All Canonical' tab button. If ony one is used it will render the default global nav.
+
 If the `$breakpoint-navigation-threshold` Vanilla variable is overridden in your project, you will need to set this option on the global nav.
 
 For example, to set the `breakpoint` to `1036`:
@@ -57,7 +59,7 @@ For example, to set the `breakpoint` to `1036`:
 <script src="/node_modules/@canonical/global-nav/dist/index.js"></script>
 
 <script>
-  canonicalGlobalNav.createNav({ breakpoint: 1036 });
+  canonicalGlobalNav.createNav({ breakpoint: 1036, mobileContainerSelector: "global-nav-mobile", desktopContainerSelector: "global-nav-desktop" });
 </script>
 ```
 

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -351,7 +351,7 @@ function addListeners(wrapper, breakpoint) {
   /* eslint-enable */
 }
 
-export const createNav = ({ breakpoint = 620 } = {}) => {
+export const createNav = ({ breakpoint = 620, mobileContainerSelector, desktopContainerSelector } = {}) => {
   // Recruitment call to action
   // eslint-disable-next-line no-console
   console.log(
@@ -359,6 +359,8 @@ export const createNav = ({ breakpoint = 620 } = {}) => {
   );
 
   const container = document.querySelector('.global-nav'); //eslint-disable-line
+  const mobileContainer = document.querySelector(mobileContainerSelector); //eslint-disable-line
+  const desktopContainer = document.querySelector(desktopContainerSelector); //eslint-disable-line
 
   // Build global nav components
   const skipLink = createFromHTML(
@@ -387,6 +389,16 @@ export const createNav = ({ breakpoint = 620 } = {}) => {
   // Attach to the DOM
   document.body.insertBefore(skipLink, document.body.firstElementChild); //eslint-disable-line
   document.body.appendChild(overlay); //eslint-disable-line
+
+  if (mobileContainer && desktopContainer) {
+    const mobileDropdownList = mobileDropdown.querySelector("ul.p-navigation__items");
+    const globalNavButton = navItem.querySelector("a");
+    desktopContainer.appendChild(navDropdown);
+    mobileContainer.prepend(mobileDropdownList);
+    container.prepend(globalNavButton);
+    return;
+  }
+
   document.body.appendChild(navDropdown); //eslint-disable-line
 
   if (container) {


### PR DESCRIPTION
`mobileContainerSelector` and `desktopContainerSelector`: Selectors (can be 'id' or 'class') of where to attach the mobile and desktop views of the global-nav. This will also circumvent the default eventListeners being attached as they are dependent on the default structure, so custom JS will be nessacary. Also in this case, the the class `global-nav` should still be used to indicate the position of the 'All Canonical' tab button. If ony one is used it will render the default global nav.