### PR TITLE
Update link to careers/engineering in browser console

### DIFF
--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -333,7 +333,7 @@ export const createNav = ({
   // Recruitment call to action
   // eslint-disable-next-line no-console
   console.log(
-    'Interested in what makes us tick? Then we are interested in you! See our jobs page for more info: https://canonical.com/careers/all?filter=Engineering'
+    'Interested in what makes us tick? Then we are interested in you! See our jobs page for more info: https://canonical.com/careers/engineering'
   );
 
   const container = document.querySelector('.global-nav'); //eslint-disable-line


### PR DESCRIPTION
Global nav prints a message in the browser console to lead folks playing with developer tools to our Careers page. It currently links to the [list of Engineering positions](https://canonical.com/careers/all?filter=Engineering): this PR changes the link to the [new Engineering page](https://canonical.com/careers/engineering), as it also showcases the tracks.